### PR TITLE
Added reporters to docstring of simulation class

### DIFF
--- a/polychrom/simulation.py
+++ b/polychrom/simulation.py
@@ -217,6 +217,8 @@ class Simulation(object):
             Using one decimal is safe most of the time, and reduces storage to 40% of int32.
             NOTE that using periodic boundary conditions will make storage advantage less.
 
+        reporters: list, optional 
+            List of reporters to use in the simulation.
 
         """
         default_args = {


### PR DESCRIPTION
Problem:
The reporters argument was not mentioned in the docstring of simulation.Simulation class. 
This meant that it is currently not visible in the argument is invisible in the readthedocs.

Proposed solution: 
Added
```
reporters: list, optional 
            List of reporters to use in the simulation.
```

Feel free to suggest alterations to the docstring entry if you do not find it to describe what you want it to.