### PR TITLE
Update default precision from mixed to single

### DIFF
--- a/polychrom/simulation.py
+++ b/polychrom/simulation.py
@@ -207,7 +207,7 @@ class Simulation(object):
             Shout out loud about every change.
 
         precision: str, optional (not recommended to change)
-            mixed is optimal for most situations.
+            single is the default now, because mixed is much slower on 3080 and other new GPUs 
             If you are using double precision, it will be slower by a factor of 10 or so.
 
         save_decimals: int or False, optional
@@ -231,7 +231,7 @@ class Simulation(object):
             "mass": 100,
             "reporters": [],
             "max_Ek": 10,
-            "precision": "mixed",
+            "precision": "single",
             "save_decimals": 2,
             "verbose": False,
         }


### PR DESCRIPTION
This is a simple PR that changes the default precision from single to mixed. 

**What is mixed precision?** It computes forces in single precision, but does integration in double precision. 

**Why did we use it before** Because OpenMM manual  [indicates](http://docs.openmm.org/latest/userguide/library/04_platform_specifics.html) that mixed precision leads to better kinetic energy convservation, while being benign. 

**Why are we getting rid of it now**?  My tests indicate that mixed precision incurs 3-7% penalty on 1080 Ti, but 30% penalty on 3080. Also, single/double ratio changed from ~16x to ~32x (see details in [this thread](https://simtk.org/plugins/phpBB/viewtopicPhpbb.php?f=161&t=14831&p=0&start=0&view=&sid=4cdb13847d27d29b852c8fe29b9b6acd)) but it seems from the numbers above that the decrease is much more drastic. It may be that in the future the performance penalty may increase even further, so for the sake of being future-proof I'm getting rid of it now. 

**What do you want me to review**? I'm asking you to acknowledge that you're OK with this change by approving this PR. If you think it's necessary, you should do tests on your side that would confirm whether mixed precision is indeed different from single precision. Please post your results in this PR. I expect this PR to be merged at the end of August 2022. 