### PR TITLE
Changed library for Callable

### DIFF
--- a/polychrom/starting_conformations.py
+++ b/polychrom/starting_conformations.py
@@ -1,6 +1,6 @@
 import warnings
 from math import sqrt, sin, cos
-from collections.abc import Callable
+from typing import Callable
 from typing import Tuple
 import numpy as np
 


### PR DESCRIPTION
Got the error `TypeError: 'ABCMeta' object is not subscriptable` when running example.py script. Managed to solve inspired by [this StackOverflow post](https://stackoverflow.com/questions/59955751/abcmeta-object-is-not-subscriptable-when-trying-to-annotate-a-hash-variable)