### PR TITLE
Fixed error arising in one-particle sims

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,6 +27,7 @@ jobs:
           pip install cython
           pip install -r requirements.txt 
           pip install -e . 
+          conda install -c conda-forge libstdcxx-ng=12
       - name: Test with pytest
         run: |          
           pytest

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,24 @@ Polychrom requires OpenMM, which can be installed through conda: ``conda install
 
 CUDA is the fastest GPU-assisted backend to OpenMM. You would need to have the required version of CUDA, or install OpenMM compiled for your version of CUDA. 
 
-Other dependencies are simple, and are listed in requirements.txt. All but joblib are installable from either conda/pip, and joblib installs well with pip. 
+Other dependencies are simple, and are listed in requirements.txt. All but joblib are installable from either conda/pip, and joblib installs well with pip.
+
+Installation errors and possible fixes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Error:
+After installation, importing openmm or running polychrom code leads to the error:
+
+.. code-block:: console
+   
+   version GLIBCXX_3.4.30 not found
+
+Fix:
+
+.. code-block:: console
+   
+   conda install -c conda-forge libstdcxx-ng=12
+
 
 
 Structure

--- a/polychrom/polymer_analyses.py
+++ b/polychrom/polymer_analyses.py
@@ -1,7 +1,7 @@
 # Code written by: Maksim Imakaev (imakaev@mit.edu)
 """
 Analyses of polymer conformations
-=================================
+------------------------------
 
 
 This module presents a collection of utils to work with polymer conformations.

--- a/polychrom/simulation.py
+++ b/polychrom/simulation.py
@@ -790,7 +790,7 @@ class Simulation(object):
         bonds = np.sqrt(np.sum(np.diff(pos, axis=0) ** 2, axis=1))
         sbonds = np.sort(bonds)
         vel = state.getVelocities()
-        mass = self.system.getParticleMass(1)
+        mass = self.system.getParticleMass(0)
         vkT = np.array(vel / simtk.unit.sqrt(self.kT / mass), dtype=float)
         self.velocs = vkT
         EkPerParticle = 0.5 * np.sum(vkT**2, axis=1)


### PR DESCRIPTION
For one particle simulations, the index 1 does not exist so it threw an error when trying to retrieve mass of particle with index 1