### PR TITLE
Fixed extra uncaught one-particle error

### DIFF
--- a/polychrom/simulation.py
+++ b/polychrom/simulation.py
@@ -754,7 +754,7 @@ class Simulation(object):
         if self.integrator_type.lower() == "variablelangevin" or self.integrator_type.lower() == "variableverlet":
             dt = self.integrator.getStepSize()
             msg += "dt=%.1lffs " % (dt / simtk.unit.femtosecond)
-            mass = self.system.getParticleMass(1)
+            mass = self.system.getParticleMass(0)
             dx = simtk.unit.sqrt(2.0 * eK * self.kT / mass) * dt
             msg += "dx=%.2lfpm " % (dx / simtk.unit.nanometer * 1000.0)
 


### PR DESCRIPTION
When run with only one particle gives the error 'OpenMMException: Assertion failure at System.cpp:55.  Index out of range'

## Description

_Describe what this PR is for_


## PR Checklist

- [] apply "black" to the whole codebase (`black .`) 
- [] apply isort to the codebase (`isort .`)
- [] fun `flake8` and try to resolve all the issues (work in progress!)
