### PR TITLE
Make masses changeable

### DIFF
--- a/polychrom/simulation.py
+++ b/polychrom/simulation.py
@@ -323,6 +323,8 @@ class Simulation(object):
 
         self.N: int = kwargs["N"]
 
+        self.masses = np.zeros(self.N, dtype=float) + self.kwargs["mass"]
+
         self.verbose: bool = kwargs["verbose"]
         self.reporters = kwargs["reporters"]
         self.forces_applied: bool = False
@@ -512,7 +514,6 @@ class Simulation(object):
         if self.forces_applied:
             return
 
-        self.masses = np.zeros(self.N, dtype=float) + self.kwargs["mass"]
         for mass in self.masses:
             self.system.addParticle(mass)
 


### PR DESCRIPTION
## Description

move the initialization of `Simulation.masses` to the constructor, such that it can be edited before the actual `openmm.System` and `openmm.Context` are created. Necessary for particles with different masses.

## PR Checklist

<moved only a single line of code>

- [] apply "black" to the whole codebase (`black .`) 
- [] apply isort to the codebase (`isort .`)
- [] fun `flake8` and try to resolve all the issues (work in progress!)
